### PR TITLE
add repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.4"
 edition = "2021"
 license = "MIT"
 description = "Cordwood: non-archival blockchain key-value store with fast recent state retrieval."
+repository = "https://github.com/Determinant/cordwood"
 
 [dependencies]
 enum-as-inner = "0.6.0"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).

Also see [report about your crates](https://rust-digger.code-maven.com/users/determinant)